### PR TITLE
👷 (publish): use changesets publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          publish: pnpm exec changeset publish
           commit: '🔖 version packages'
           title: '🔖 version packages'
         env:


### PR DESCRIPTION
It looks like #3 turned off publishing completely instead of using changesets publish command. Let's bring publishing back