### PR TITLE
🏗️ (prettier): add import sorting to the base config

### DIFF
--- a/.changeset/tasty-wombats-obey.md
+++ b/.changeset/tasty-wombats-obey.md
@@ -1,0 +1,7 @@
+---
+"@m-social/prettier-config-svelte": minor
+"@m-social/prettier-config-react": minor
+"@m-social/prettier-config": minor
+---
+
+🏗️ add import sorting to the base config

--- a/configs/prettier/base/package.json
+++ b/configs/prettier/base/package.json
@@ -50,7 +50,11 @@
 		"build": "tsdown"
 	},
 	"dependencies": {
+		"@ianvs/prettier-plugin-sort-imports": "^4.7.1",
 		"@prettier/plugin-oxc": "^0.1.3"
+	},
+	"devDependencies": {
+		"@m-social/prettier-config-utils": "workspace:*"
 	},
 	"peerDependencies": {
 		"prettier": "catalog:production"

--- a/configs/prettier/base/src/index.ts
+++ b/configs/prettier/base/src/index.ts
@@ -1,6 +1,11 @@
+/// <reference types="@ianvs/prettier-plugin-sort-imports" />
+
 import { createRequire } from "node:module";
 
+import { fsdImportSorters, internalImportSorter } from "@m-social/prettier-config-utils";
 import type { Config } from "prettier";
+
+const SUPPORTED_ALIASES = ["$", "@/", "#"];
 
 const require = createRequire(import.meta.url);
 
@@ -18,7 +23,25 @@ const baseConfig = {
 	arrowParens: "always",
 	endOfLine: "lf",
 	singleAttributePerLine: false,
-	plugins: [require.resolve("@prettier/plugin-oxc")],
+	plugins: [
+		require.resolve("@prettier/plugin-oxc"),
+		require.resolve("@ianvs/prettier-plugin-sort-imports"),
+	],
+	importOrder: [
+		"<BUILTIN_MODULES>",
+		"",
+		"<THIRD_PARTY_MODULES>",
+		"",
+		// #region internal imports
+		...fsdImportSorters(SUPPORTED_ALIASES),
+		"",
+		internalImportSorter(SUPPORTED_ALIASES),
+		// #endregion
+		"",
+		`^[.]`, // relative imports
+		"",
+	],
+	importOrderTypeScriptVersion: "5.0.0",
 } satisfies Config;
 
 export default baseConfig;

--- a/configs/prettier/react/package.json
+++ b/configs/prettier/react/package.json
@@ -51,7 +51,6 @@
 		"build": "tsdown"
 	},
 	"dependencies": {
-		"@ianvs/prettier-plugin-sort-imports": "catalog:production",
 		"@m-social/prettier-config": "workspace:*"
 	},
 	"devDependencies": {

--- a/configs/prettier/react/src/index.ts
+++ b/configs/prettier/react/src/index.ts
@@ -1,7 +1,3 @@
-/// <reference types="@ianvs/prettier-plugin-sort-imports" />
-
-import { createRequire } from "node:module";
-
 import baseConfig from "@m-social/prettier-config";
 import {
 	fsdImportSorters,
@@ -14,11 +10,8 @@ const SUPPORTED_ALIASES = ["$", "@/", "#"];
 
 const linkedStyle = "/[^/]+[.]s?css([?].*)?$";
 
-const require = createRequire(import.meta.url);
-
 const reactConfig = {
 	...baseConfig,
-	plugins: [...baseConfig.plugins, require.resolve("@ianvs/prettier-plugin-sort-imports")],
 	importOrder: [
 		// #region react & frameworks
 		packageSorter("react"),
@@ -40,7 +33,6 @@ const reactConfig = {
 		`^[.]${linkedStyle}`, // linked style
 		"",
 	],
-	importOrderTypeScriptVersion: "5.0.0",
 } satisfies Config;
 
 export default reactConfig;

--- a/configs/prettier/svelte/package.json
+++ b/configs/prettier/svelte/package.json
@@ -51,7 +51,6 @@
 		"build": "tsdown"
 	},
 	"dependencies": {
-		"@ianvs/prettier-plugin-sort-imports": "catalog:production",
 		"@m-social/prettier-config": "workspace:*",
 		"prettier-plugin-svelte": "^3.5.1"
 	},

--- a/configs/prettier/svelte/src/index.ts
+++ b/configs/prettier/svelte/src/index.ts
@@ -1,4 +1,3 @@
-/// <reference types="@ianvs/prettier-plugin-sort-imports" />
 import { createRequire } from "node:module";
 
 import baseConfig from "@m-social/prettier-config";
@@ -15,11 +14,7 @@ const require = createRequire(import.meta.url);
 
 const svelteConfig = {
 	...baseConfig,
-	plugins: [
-		...baseConfig.plugins,
-		require.resolve("prettier-plugin-svelte"),
-		require.resolve("@ianvs/prettier-plugin-sort-imports"),
-	],
+	plugins: [...baseConfig.plugins, require.resolve("prettier-plugin-svelte")],
 	importOrder: [
 		packageSorter("svelte"),
 		"",
@@ -39,7 +34,6 @@ const svelteConfig = {
 		"^[.]", // relative imports
 		"",
 	],
-	importOrderTypeScriptVersion: "5.0.0",
 	overrides: [{ files: "*.svelte", options: { parser: "svelte" } }],
 } satisfies Config;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,6 @@ catalogs:
       specifier: ^10.2.0
       version: 10.2.0
   production:
-    '@ianvs/prettier-plugin-sort-imports':
-      specifier: ^4.7.1
-      version: 4.7.1
     eslint:
       specifier: ^9.22.0 || ^10.0.0
       version: 10.2.0
@@ -188,18 +185,22 @@ importers:
 
   configs/prettier/base:
     dependencies:
+      '@ianvs/prettier-plugin-sort-imports':
+        specifier: ^4.7.1
+        version: 4.7.1(@prettier/plugin-oxc@0.1.3)(prettier@3.8.3)
       '@prettier/plugin-oxc':
         specifier: ^0.1.3
         version: 0.1.3
       prettier:
         specifier: catalog:production
         version: 3.8.3
+    devDependencies:
+      '@m-social/prettier-config-utils':
+        specifier: workspace:*
+        version: link:../utils
 
   configs/prettier/react:
     dependencies:
-      '@ianvs/prettier-plugin-sort-imports':
-        specifier: catalog:production
-        version: 4.7.1(@prettier/plugin-oxc@0.1.3)(prettier@3.8.3)
       '@m-social/prettier-config':
         specifier: workspace:*
         version: link:../base
@@ -213,9 +214,6 @@ importers:
 
   configs/prettier/svelte:
     dependencies:
-      '@ianvs/prettier-plugin-sort-imports':
-        specifier: catalog:production
-        version: 4.7.1(@prettier/plugin-oxc@0.1.3)(prettier@3.8.3)
       '@m-social/prettier-config':
         specifier: workspace:*
         version: link:../base

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,6 @@ catalogs:
     eslint: ^10.2.0
     prettier: ^3.6.0
   production:
-    "@ianvs/prettier-plugin-sort-imports": ^4.7.1
     eslint: ^9.22.0 || ^10.0.0
     globals: ^17.4.0
     prettier: ^3.6.0


### PR DESCRIPTION
For consistency with other formatting tools, I added import sorting to the base config